### PR TITLE
chore(DEV-1396): Resolve Deprecation Warnings

### DIFF
--- a/.github/workflows/workflow-cd-argocd.yml
+++ b/.github/workflows/workflow-cd-argocd.yml
@@ -115,7 +115,8 @@ jobs:
           role-skip-session-tagging: true
 
       - name: Deploy
-        uses: cloudposse/github-action-deploy-argocd@0.5.0
+        #uses: cloudposse/github-action-deploy-argocd@0.5.0
+        uses: cloudposse/github-action-deploy-argocd@DEV-1396/deprecation-warnings
         id: deploy
         with:
           toolchain: ${{ inputs.toolchain }}

--- a/.github/workflows/workflow-cd-argocd.yml
+++ b/.github/workflows/workflow-cd-argocd.yml
@@ -115,8 +115,7 @@ jobs:
           role-skip-session-tagging: true
 
       - name: Deploy
-        #uses: cloudposse/github-action-deploy-argocd@0.5.0
-        uses: cloudposse/github-action-deploy-argocd@DEV-1396/deprecation-warnings
+        uses: cloudposse/github-action-deploy-argocd@0.8.0
         id: deploy
         with:
           toolchain: ${{ inputs.toolchain }}

--- a/.github/workflows/workflow-cd-preview-argocd.yml
+++ b/.github/workflows/workflow-cd-preview-argocd.yml
@@ -91,6 +91,10 @@ on:
         type: boolean
         description: "Wait until ArgoCD successfully apply the changes"
         default: false
+      check-retry-interval:
+        description: 'Check retry interval (in seconds) (for synchronously mode)'
+        required: false
+        default: "30"
     secrets:
       secret-outputs-passphrase:
         description: "Passphrase to encrypt/decrypt secret outputs with gpg. For more information [read](https://github.com/cloudposse/github-action-secret-outputs)"
@@ -195,6 +199,7 @@ jobs:
           github-pat: ${{ secrets.github-private-actions-pat }}
           repository: ${{ inputs.organization }}/${{ inputs.repository }}
           ref: ${{ github.sha }}
+          check-retry-interval: ${{ inputs.check-retry-interval }}
 
   destroy:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow-cd-preview-argocd.yml
+++ b/.github/workflows/workflow-cd-preview-argocd.yml
@@ -91,6 +91,11 @@ on:
         type: boolean
         description: "Wait until ArgoCD successfully apply the changes"
         default: false
+      check-retry-count:
+        type: string
+        description: 'Check retry count (for synchronously mode)'
+        required: false
+        default: "10"
       check-retry-interval:
         type: string
         description: 'Check retry interval (in seconds) (for synchronously mode)'
@@ -180,12 +185,13 @@ jobs:
           role-skip-session-tagging: true
 
       - name: Deploy
-        #uses: cloudposse/github-action-deploy-argocd@0.5.0
-        uses: cloudposse/github-action-deploy-argocd@DEV-1396/deprecation-warnings
+        uses: cloudposse/github-action-deploy-argocd@0.8.0
         id: deploy
         with:
           toolchain: ${{ inputs.toolchain }}
           synchronously: ${{ inputs.synchronously }}
+          check-retry-count: ${{ inputs.check-retry-count }}
+          check-retry-interval: ${{ inputs.check-retry-interval }}
           path: ${{ inputs.path }}
           values_file: ${{ format(inputs.values_file, steps.environment.outputs.name) }}
           application: ${{ inputs.repository }}
@@ -200,7 +206,6 @@ jobs:
           github-pat: ${{ secrets.github-private-actions-pat }}
           repository: ${{ inputs.organization }}/${{ inputs.repository }}
           ref: ${{ github.sha }}
-          check-retry-interval: ${{ inputs.check-retry-interval }}
 
   destroy:
     runs-on: ubuntu-latest
@@ -250,8 +255,7 @@ jobs:
           role-skip-session-tagging: true
 
       - name: Destroy
-        #uses: cloudposse/github-action-deploy-argocd@0.5.0
-        uses: cloudposse/github-action-deploy-argocd@DEV-1396/deprecation-warnings
+        uses: cloudposse/github-action-deploy-argocd@0.8.0
         if: ${{ steps.deployment.outputs.id != '' }}
         id: deploy
         with:

--- a/.github/workflows/workflow-cd-preview-argocd.yml
+++ b/.github/workflows/workflow-cd-preview-argocd.yml
@@ -175,7 +175,8 @@ jobs:
           role-skip-session-tagging: true
 
       - name: Deploy
-        uses: cloudposse/github-action-deploy-argocd@0.5.0
+        #uses: cloudposse/github-action-deploy-argocd@0.5.0
+        uses: cloudposse/github-action-deploy-argocd@DEV-1396/deprecation-warnings
         id: deploy
         with:
           toolchain: ${{ inputs.toolchain }}
@@ -243,7 +244,8 @@ jobs:
           role-skip-session-tagging: true
 
       - name: Destroy
-        uses: cloudposse/github-action-deploy-argocd@0.5.0
+        #uses: cloudposse/github-action-deploy-argocd@0.5.0
+        uses: cloudposse/github-action-deploy-argocd@DEV-1396/deprecation-warnings
         if: ${{ steps.deployment.outputs.id != '' }}
         id: deploy
         with:

--- a/.github/workflows/workflow-cd-preview-argocd.yml
+++ b/.github/workflows/workflow-cd-preview-argocd.yml
@@ -92,6 +92,7 @@ on:
         description: "Wait until ArgoCD successfully apply the changes"
         default: false
       check-retry-interval:
+        type: string
         description: 'Check retry interval (in seconds) (for synchronously mode)'
         required: false
         default: "30"


### PR DESCRIPTION
## what
- Pointing to the new version of `cloudposse/github-action-deploy-argocd`

## why
- We are using the https://github.com/theowenyoung/git-url-parse action in our [argocd](https://github.com/cloudposse/github-action-deploy-argocd) reusable action. The upstream action is using node 12 and set-output and hasn't been updated in 3 years. It's throwing warnings every time it runs. We should either fork and update that action or find a replacement.

## references
- DEV-1396
- https://github.com/cloudposse/github-action-deploy-argocd/pull/42