### PR TITLE
udpate to always lowercase org

### DIFF
--- a/.github/workflows/workflow-ci-dockerized-app-build.yml
+++ b/.github/workflows/workflow-ci-dockerized-app-build.yml
@@ -1,8 +1,8 @@
 name: |-
   CI - Build Docker image
-  
+
   Build Docker image and push it to ECR
-  
+
   ### Usage 
 
   ```yaml
@@ -72,6 +72,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # https://github.com/orgs/community/discussions/27086#discussioncomment-3254548
+      - name: set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: "${{ github.repository_owner }}"
+
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
@@ -82,11 +89,11 @@ jobs:
         id: build
         uses: cloudposse/github-action-docker-build-push@1.14.0
         with:
-          organization: ${{ inputs.organization }}
+          organization: ${{ env.OWNER_LC }}
           repository: ${{ inputs.repository }}
           registry: ${{ secrets.registry }}
-          cache-from: "type=registry,ref=${{ secrets.registry }}/${{ inputs.organization }}/${{ inputs.repository }}:cache"
-          cache-to: "mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${{ secrets.registry }}/${{ inputs.organization }}/${{ inputs.repository }}:cache"
+          cache-from: "type=registry,ref=${{ secrets.registry }}/${{ env.OWNER_LC }}/${{ inputs.repository }}:cache"
+          cache-to: "mode=max,image-manifest=true,oci-mediatypes=true,type=registry,ref=${{ secrets.registry }}/${{ env.OWNER_LC }}/${{ inputs.repository }}:cache"
 
       - uses: cloudposse/github-action-secret-outputs@0.1.1
         id: image
@@ -102,7 +109,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     if: ${{ inputs.tests_enabled }}
-    needs: [ build ]
+    needs: [build]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -121,4 +128,3 @@ jobs:
           service: app
           command: test/test.sh
           registry: ${{ secrets.registry }}
-

--- a/.github/workflows/workflow-ci-dockerized-app-promote.yml
+++ b/.github/workflows/workflow-ci-dockerized-app-promote.yml
@@ -1,6 +1,6 @@
 name: |-
   CI - Promote Docker image 
-  
+
   Promote Docker image to specific version tag and push it to ECR
 
   ### Usage 
@@ -88,6 +88,13 @@ jobs:
           aws-region: ${{ secrets.ecr-region }}
           role-to-assume: ${{ secrets.ecr-iam-role }}
 
+      # https://github.com/orgs/community/discussions/27086#discussioncomment-3254548
+      - name: set lower case owner name
+        run: |
+          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+        env:
+          OWNER: "${{ github.repository_owner }}"
+
       - name: Context
         id: context
         uses: cloudposse/github-action-yaml-config-query@0.1.3
@@ -103,7 +110,7 @@ jobs:
         id: promote
         with:
           registry: ${{ secrets.registry }}
-          organization: ${{ inputs.organization }}
+          organization: ${{ env.OWNER_LC }}
           repository: ${{ steps.context.outputs.image }}
           from: sha-${{ github.sha }}
           to: ${{ inputs.version }}
@@ -123,7 +130,7 @@ jobs:
           matrix-key: ${{ inputs.matrix-key }}
           outputs: |
             image: ${{ steps.image.outputs.out }}
-            tag: ${{ steps.promote.outputs.tag }}            
+            tag: ${{ steps.promote.outputs.tag }}
 
     outputs:
       image: ${{ fromJson(steps.outputs.outputs.result).image }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to consistently use a lower-case version of the repository owner name when building and promoting Docker images. This ensures compatibility with Docker registries that require lower-case organization names and prevents potential issues related to case sensitivity.

**Workflow consistency and compatibility:**

* Added a step in both `.github/workflows/workflow-ci-dockerized-app-build.yml` and `.github/workflows/workflow-ci-dockerized-app-promote.yml` to set an `OWNER_LC` environment variable containing the lower-case repository owner name, following community best practices. [[1]](diffhunk://#diff-721ff9f75e9474f13691c4c74ab183308461cfc1a620041258d057922e0f9719R75-R81) [[2]](diffhunk://#diff-ccbd6c8c24c7305a2e5034e570eb6b7a9911765c4709121041d8bac03d995f1fR91-R97)
* Updated references to the Docker image organization in both workflows to use `OWNER_LC` instead of the original input or variable, ensuring all Docker image tags and cache references use the lower-case owner. [[1]](diffhunk://#diff-721ff9f75e9474f13691c4c74ab183308461cfc1a620041258d057922e0f9719L85-R96) [[2]](diffhunk://#diff-ccbd6c8c24c7305a2e5034e570eb6b7a9911765c4709121041d8bac03d995f1fL106-R113)

These changes help prevent issues with Docker registries that enforce lower-case naming conventions.